### PR TITLE
FIX Permissions issues for backend users

### DIFF
--- a/code/controllers/DynamicListAdmin.php
+++ b/code/controllers/DynamicListAdmin.php
@@ -33,14 +33,7 @@ class DynamicListAdmin extends ModelAdmin {
 		'DynamicList' => 'DynamicListCsvLoader',
 	);
 
-	public function ImportForm() {
-		$form = parent::ImportForm();
-		$form->Fields()->replaceField('EmptyBeforeImport', new CheckboxField('EmptyBeforeImport', 'Clear Database before import', false));
-		return $form;
-	}
-
 }
-
 
 class DynamicListCsvLoader extends CsvBulkLoader {
 	public function __construct($objectClass) {

--- a/code/dataobjects/DynamicList.php
+++ b/code/dataobjects/DynamicList.php
@@ -32,6 +32,36 @@ class DynamicList extends DataObject {
 			$item->delete();
 		}
 	}
+	
+	public function canView($member = null) {
+		return true;
+	}
+	
+	/**
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canEdit($member = null) {
+		return Permission::check('CMS_ACCESS_DynamicListAdmin', 'any', $member);
+	}
+
+	/**
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canDelete($member = null) {
+		return Permission::check('CMS_ACCESS_DynamicListAdmin', 'any', $member);
+	}
+
+	/**
+	 * @todo Should canCreate be a static method?
+	 *
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canCreate($member = null) {
+		return Permission::check('CMS_ACCESS_DynamicListAdmin', 'any', $member);
+	}
 
 	/**
 	 * Convenience method for getting a data list
@@ -57,4 +87,5 @@ class DynamicList extends DataObject {
 
 		return $item;
 	}
+
 }

--- a/code/dataobjects/DynamicListItem.php
+++ b/code/dataobjects/DynamicListItem.php
@@ -57,5 +57,35 @@ class DynamicListItem extends DataObject {
 			$this->Sort = DB::query("SELECT MAX(\"Sort\") + 1 FROM \"DynamicListItem\" WHERE \"ListID\" = $parentID")->value();
 		}
 	}
+	
+	public function canView($member = null) {
+		return true;
+	}
+	
+	/**
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canEdit($member = null) {
+		return Permission::check('CMS_ACCESS_DynamicListAdmin', 'any', $member);
+	}
+
+	/**
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canDelete($member = null) {
+		return Permission::check('CMS_ACCESS_DynamicListAdmin', 'any', $member);
+	}
+
+	/**
+	 * @todo Should canCreate be a static method?
+	 *
+	 * @param Member $member
+	 * @return boolean
+	 */
+	public function canCreate($member = null) {
+		return Permission::check('CMS_ACCESS_DynamicListAdmin', 'any', $member);
+	}
 }
 ?>


### PR DESCRIPTION
Make sure that users who have access to the CMS section can actually edit the
items
Remove import form override that defaulted the 'clear' checkbox to unchecked
as that is now the SS3 default
